### PR TITLE
Kleine Änderungen an der Klasse und Behebung von Warnungen

### DIFF
--- a/chapters/200_grundlagen.tex
+++ b/chapters/200_grundlagen.tex
@@ -1,11 +1,11 @@
 \subsection{Attributive Language with Complement
-($\ALC$)}\label{attributive-language-with-complement-alc}
+(\texorpdfstring{$\ALC$}{ALC})}\label{attributive-language-with-complement-alc}
 
 \subsubsection{Konzept- und Rollennamen}\label{konzept--und-rollennamen}
 
 Konzept- und Rollennamen sind abzählbar unendliche und disjunkte (durch Groß- und Kleinschreibung) Mengen.
 
-\subsubsection{$\ALC$: Syntax}\label{alcsyntax}
+\subsubsection{\texorpdfstring{$\ALC$}{ALC}: Syntax}\label{alcsyntax}
 
 \theoremstyle{definition}
 \begin{definition}{$\ALC$-Konzepte} \\
@@ -65,7 +65,7 @@ Also zum Beispiel steht $\forall r.(\exists r.A \sqcap B)$ für $\forall r.((\ex
 
 Desweiteren is keine Präzedenz zwischen $\sqcap$ und $\sqcup$ definiert worden: Daher müssen Klammern verwendet werden!
 
-\subsubsection{$\ALC$: Semantik}
+\subsubsection{\texorpdfstring{$\ALC$}{ALC}: Semantik}
 
 \begin{definition}{$\ALC$ Semantik} \\
 Eine \emph{Interpretation} $\MI$ ist Paar ($\Delta^{\MI}$,$\cdot^{\MI}$) mit
@@ -312,11 +312,11 @@ $T \vDash C \equiv D$ \emph{gdw.} $T \vDash \top \sqsubseteq \left( C \sqcap D \
 
 Dies heißt für uns, dass ein Algorithmus für eines der Probleme auch für die anderen beiden verwendet werden können. Alle drei Probleme haben dieselbe Komplexität (in $\ALC$). Daher werden wir uns im Folgenden hauptsächlich auch Erfüllbarkeit konzentrieren.
 
-\subsection{Erweiterungen von $\ALC$}\label{erweiterungen-von-alc}
+\subsection{Erweiterungen von \texorpdfstring{$\ALC$}{ALC}}\label{erweiterungen-von-alc}
 
 Wir betrachten exemplarisch die beiden Erweiterungen $\ALCI$ und $\ALCQ$ von $\ALC$. Es existieren viel mehr Erweiterungen (z.B.: um spezielle Rolleniterpretationen, temporale Operatoren etc.). Diese können auch kombiniert werden, z.B.: $\ALCQI$.
 
-\subsubsection{Inverse Rollen ($\ALCI$)}\label{inverse-rollen-alci}
+\subsubsection{Inverse Rollen (\texorpdfstring{$\ALCI$}{ALCI})}\label{inverse-rollen-alci}
 
 Zunächst betrachten wir $\ALCI$, das $\ALC$ um die Möglichkeit inverse Rollen in Existenz- und Werterestriktionen zu benutzen erweitert.
 
@@ -326,7 +326,7 @@ Rolle} zu $r$. Wir definieren \\
 $\left( r^{-} \right)^{\MI} = \left\{ \left( e,d \right)\  \right|\ \left( d,e \right) \in r^{\MI}\}$
 \end{definition}
 
-\subsubsection{Zahlenrestriktion ($\ALCQ$)}\label{zahlenrestriktion-alcq}
+\subsubsection{Zahlenrestriktion (\texorpdfstring{$\ALCQ$}{ALCQ})}\label{zahlenrestriktion-alcq}
 
 \begin{definition}{Zahlenrestriktion}
 Für jede natürliche Zahl $n$, jeden Rollennamen $r$ und

--- a/chapters/200_grundlagen.tex
+++ b/chapters/200_grundlagen.tex
@@ -158,7 +158,7 @@ TBoxen definieren Konzepte und setzten diese zueinander in Beziehung.
 \emph{TBox} ist endliche Menge von Konzeptinklusionen. \\
 Wir verwenden $C \equiv D$ als Abkürzung für $C \sqsubseteq D$, $D \sqsubseteq C$. 
 
-Wir lesen $C \equiv D$ als ``$C$ impliziert $D$''.
+Wir lesen $C \equiv D$ als \enquote{$C$ impliziert $D$}.
 \end{definition}
 
 \subsubsection{TBox-Sematik}\label{tboxsemantik}
@@ -267,7 +267,7 @@ Die Schlussfolgerungsprobleme werden dazu genutzt Modellierungsfehler in Ontolog
 \subsubsection{Subsumtion als Ordnungsrelation}\label{subordn}
 
 \begin{lemma} 
-Für jede TBox $\MT$ ist die Relation ``$\sqsubseteq$ bzgl. $\MT$''
+    Für jede TBox $\MT$ ist die Relation \enquote{$\sqsubseteq$ bzgl. $\MT$}
 
 \begin{itemize}
   \item reflexiv ($\MT \vDash C \sqsubseteq C$) und

--- a/chapters/300_ausdruckstaerke_etc.tex
+++ b/chapters/300_ausdruckstaerke_etc.tex
@@ -290,7 +290,7 @@ Es gilt:
 
 Sie gilt allerdings für verschiedene Klassen von Interpretationen, wie die Klasse aller endlichen Interpretationen oder die Klasse aller Interpretationen mit endlicher Verweigungszahl.
 
-\subsubsection{Bisimulation für Erweiterungen von $\ALCI$}\label{bisimulation-in-alci}
+\subsubsection{Bisimulation für Erweiterungen von \texorpdfstring{$\ALCI$}{ALCI}}\label{bisimulation-in-alci}
 
 Für $\ALCI$, $\ALCQ$ und $\ALCQI$ gibt es ebenfalls Bisimulationsbegriffe.
 

--- a/chapters/300_ausdruckstaerke_etc.tex
+++ b/chapters/300_ausdruckstaerke_etc.tex
@@ -5,7 +5,7 @@ charakterisieren.
 
 \subsection{Bisimulation}\label{bisimulation}
 
-Bisimulation ist ein graphentheoretische Begriff, die ``Ähnlichkeit'' von Graphen beschreibt und eng mit der Ausdruckstärke von $\ALC$ zusammenhängt.
+Bisimulation ist ein graphentheoretische Begriff, die \enquote{Ähnlichkeit} von Graphen beschreibt und eng mit der Ausdruckstärke von $\ALC$ zusammenhängt.
 
 \begin{definition}{Bisimulation}
 

--- a/chapters/400_tableau.tex
+++ b/chapters/400_tableau.tex
@@ -286,7 +286,7 @@ Nun kann die Terminierung mittel Behauptung 3 beweisen:
 \textbf{T4.5d}
 
 \begin{proof}
-Wir ordnen jedem $M_i$ eine Multimenge $MM_i$ zu. Für jedes $B \in M_i$ enthält $MM_i$ die Zahl der ``n$-$Anzahl der Regelanwendungen, mittels derer $B$ generiert wurde.''
+    Wir ordnen jedem $M_i$ eine Multimenge $MM_i$ zu. Für jedes $B \in M_i$ enthält $MM_i$ die Zahl der \enquote{n$-$Anzahl der Regelanwendungen, mittels derer $B$ generiert wurde.}
 
 Weil $<$ auf $\mathcal{N}$ wohldefiniert ist, ist $<_{mul}$ auf $MM(\{0,\ldots,n\})$ wohldefiniert.
 
@@ -483,7 +483,7 @@ Offenbar wäre eine naive Implementierung nicht effizient. Dabei kann man aber e
 	\item Es wird nur ein Baum zur Zeit generiert, keine Menge
 	\item bei der $\sqcup$-Regel muss man sich also entscheiden (Heuristik); ggf. Entscheidung revidiieren (Backtracking).
 	\item Es wird nur ein Teil des Baumes (Pfad) im Speicher gehalten.
-	\item Backjumping: Führe Buch über die ``Herkunft'' von Knotenbeschriftungen und Kanten mittels Dependenzmengen. Wenn Backtracking nötig, springe direkt zu einer der Ursachen des Widerspruches zurück.
+    \item Backjumping: Führe Buch über die \enquote{Herkunft} von Knotenbeschriftungen und Kanten mittels Dependenzmengen. Wenn Backtracking nötig, springe direkt zu einer der Ursachen des Widerspruches zurück.
 \end{itemize}
 
 \subsection{ALC mit generellen TBoxen}\label{alc-mit-generellen-tboxen}
@@ -577,7 +577,7 @@ offensichtlichen Widerspruch (Nur neue Fallunterscheidung für TBox-Regel und Re
 \subsubsection{Korrektheit}\label{korrektheit}
 
 \begin{proposition}
-Wenn der Algorithmus ``erfüllbar'' zurückgibt, so ist $C_0$ erfüllbar bzgl. $\MT$
+    Wenn der Algorithmus \enquote{erfüllbar} zurückgibt, so ist $C_0$ erfüllbar bzgl. $\MT$
 \end{proposition}
 
 \textbf{T4.15}
@@ -716,7 +716,7 @@ TBoxen führen zu Backtracking:
 
 Daher wird jede $\sqcup$-Regel für \emph{Konzeptinklusion} auf \emph{jeden} Knoten angewendet!
 
-Also braucht man für eine effiziente Implementierung Optimerungstechniken, die die Dijsunktionen, soweit möglich, eliminieren (``Absorption'').
+Also braucht man für eine effiziente Implementierung Optimerungstechniken, die die Dijsunktionen, soweit möglich, eliminieren (\enquote{Absorption}).
 
 \subsubsection{Erweiterungen}
 

--- a/chapters/500_komplexitaet.tex
+++ b/chapters/500_komplexitaet.tex
@@ -84,7 +84,7 @@ Die generelle Idee der Typelimination bei Eingabe $C_0$, $\MT$:
 
 \subsubsection{Schlechte Typen}\label{schlechter-typ}
 
-Wir formalisieren ``Typen, die in keinem Modell vorkommen können''.
+Wir formalisieren \enquote{Typen, die in keinem Modell vorkommen können}.
 
 \begin{definition}{schlechter Typ}
 
@@ -96,7 +96,7 @@ Dann ist $t$ \emph{schlecht in} $\Gamma$, wenn für ein $\exists r.C \in t$ gilt
 $\left\{ C \right\} \cup \left\{ \text{D\ } \middle| \ \forall r.D \in t \right\} \subseteq t^{'}$.\end{center}
 \end{definition}
 
-Erklärung: $t$ braucht einen ``Zeugen'', es gibt aber keinen
+Erklärung: $t$ braucht einen \enquote{Zeugen}, es gibt aber keinen
 geeigneten.
 
 \textbf{T5.1cont}
@@ -130,7 +130,7 @@ Sei $n = \left| C_{0} \right| + |T|$. Proposition folgt aus:
 \end{proof}
 
 \begin{proposition}
-$\ALC$-Elim($C_0,\MT$) antwortet ``erfüllbar'' gdw. $C_0$ erfüllbar bzgl. $\MT$
+    $\ALC$-Elim($C_0,\MT$) antwortet \enquote{erfüllbar} gdw. $C_0$ erfüllbar bzgl. $\MT$
 \end{proposition}
 
 \textbf{T5.3}. 
@@ -276,7 +276,7 @@ Offensichtliche Entsprechungen:
 
 \begin{itemize}
   \item $\sqcap$-Regel, $\sqcup$-Regel, TBox-Regel finden sich wieder in der Definition eines Typs.
-  \item $\exists$-Regel und $\forall$-Regel finden sich wieder in Def. von ``schlecht''.
+  \item $\exists$-Regel und $\forall$-Regel finden sich wieder in Def. von \enquote{schlecht}.
   \item Freiheit von offensichtlichen Widersprüchen findet sich wieder in der Definition eines Typs
 \end{itemize}
 
@@ -571,7 +571,7 @@ Sei $C_0$ erfüllbar und $\MI$ ein Modell von $C_0$ und $d_0 \in C_0^{\MI.}$
 
 Beweisidee:
 
-Verwenden $\MI$, um die nichtdeterministischen Entscheidungen von $\ALC$-Worlds($C_0$) zu einem erfolgreichen Lauf zu ``lenken''.
+Verwenden $\MI$, um die nichtdeterministischen Entscheidungen von $\ALC$-Worlds($C_0$) zu einem erfolgreichen Lauf zu \enquote{lenken}.
 
 \begin{theorem}
 In $\ALC$ ist die Erfüllbarkeit von Konzepten in PSpace.

--- a/chapters/800_uebersicht.tex
+++ b/chapters/800_uebersicht.tex
@@ -1,6 +1,6 @@
-\subsection{Erfüllbarkeit in $\ALC$}
+\subsection{Erfüllbarkeit in \texorpdfstring{$\ALC$}{ALC}}
 
-\subsubsection{$\ALC$ bzgl. TBoxen}
+\subsubsection{\texorpdfstring{$\ALC$}{ALC} bzgl. TBoxen}
 
 Komplexität: ExpTime-vollständig
 
@@ -18,7 +18,7 @@ Die Vollständigkeit haben wir gezeigt, indem wir semantische Typen aus dem Mode
 
 Nun wollen wir zeigen, das das Erfüllbarkeitsproblem von $\ALC$ ExpTime-hart ist. Dazu reduzieren wir das ExpTime Spiel auf die Erfüllbarkeit von $\ALC$.
 
-\subsubsection{$\ALC$ ohne TBox}
+\subsubsection{\texorpdfstring{$\ALC$}{ALC} ohne TBox}
 
 Komplexität: PSpace-vollständig
 
@@ -36,7 +36,7 @@ Vollständigkeit: Verwende $\MI$ um die nichtdeterministischen Entscheidungen de
 
 Nun wollen wir zeigen, dass das Erfüllbarkeitsproblem von  $\ALC$ ohne TBoxen PSpace-hart ist. Dies zeigen wir, indem wir das PSpace-Spiel auf die Erfüllbarkeit reduzieren. 
 
-\subsubsection{$\ALCI$, $\ALCQ$, $\ALCQI$}
+\subsubsection{\texorpdfstring{$\ALCI$, $\ALCQ$, $\ALCQI$}{ALCI, ALCQ, ALCQI}}
 
 Für diese Variationen von $\ALC$ gelten die selben Komplexitäten wie für $\ALC$
 
@@ -44,7 +44,7 @@ Für diese Variationen von $\ALC$ gelten die selben Komplexitäten wie für $\AL
 
 Wir betrachten hier beispielhaft die Erweiterung von um konkrete Bereiche. Dazu reduzieren wir das Halteproblem für 2-Registermaschinen auf die Erfüllbarkeit dieser Erweiterung.
 
-\subsection{Erfüllbarkeit in $\EL$}
+\subsection{Erfüllbarkeit in \texorpdfstring{$\EL$}{EL}}
 
 Jedes $\EL$-Konzept ist erfüllbar bzgl. jeder TBox.
 
@@ -61,7 +61,7 @@ Subsumtion in $\EL$ kann in polynomieller Zeit entschieden werden:
 	\end{itemize}
 \end{itemize}
 
-\subsection{Subsumtion von Konzeptnamen in $\EL$ bzgl. TBox}
+\subsection{Subsumtion von Konzeptnamen in \texorpdfstring{$\EL$} bzgl. TBox}
 
 Zunächst wandeln wir eine $\EL$-TBox $\MT$ in linearer Zeit in eine TBox $\MT'$ in Normalform um, die eine konserative Erweiterung von $\MT$ ist. Dazu wenden wir erschöpfend die Regeln NF1 bis NF5 an.
 
@@ -84,9 +84,9 @@ Zunächst zeigen wir, dass die kanonische Interpretation $\MI$ ein Model von $\M
 
 Nun können wir die Vollständigkeit zeigen. Dazu zeigen wir die Kontraposition: Für alle Konzeptbamen $A,B$ gilt $A \sqsubseteq B \not\in \MT *$ impliziert $\MT \not\models A \sqsubseteq B$.
 
-\subsubsection{Erweiterungen von $\EL$}
+\subsubsection{Erweiterungen von \texorpdfstring{$\EL$}{EL}}
 
-\paragraph{$\EL\mathcal{U}_{\bot}$}
+\paragraph{\texorpdfstring{$\EL\mathcal{U}_{\bot}$}{EL}}
 
 ExpTime vollständig.
 
@@ -114,7 +114,7 @@ Schritt 3: Entferne Negation vollständig aus $\MT$
 
 Zeigen, dass $A$ erfüllbar bzgl. $\MT$ gdw. $A$ erfüllbar bzgl. der entstandenen TBox.
 
-\paragraph{$\EL\mathcal{U}$}
+\paragraph{\texorpdfstring{$\EL\mathcal{U}$}{EL}}
 
 ExpTime-vollständig
 
@@ -139,7 +139,7 @@ Wobei die Form 2 und 4 immer erfüllt ist und daher gelöscht werden kann.
 
 Nun kann man zeigen, das $A$ unerfüllbar bzgl. $\MT$ gdw. $\MT ' \models A \sqsubseteq L$
 
-\paragraph{$\EL^{\forall}$}
+\paragraph{\texorpdfstring{$\EL^{\forall}$}{EL}}
 
 ExpTime-vollständig
 
@@ -154,7 +154,7 @@ Wir können annehmen, das Disjunktion nur in den folgenden Formen vorkommt:
 
 Nun zeigen wir $\MT \models A \sqsubseteq B$ gdw. $\MT' \models A \sqsubseteq B$
 
-\paragraph{$\EL^{\leq 2}$}
+\paragraph{\texorpdfstring{$\EL^{\leq 2}$}{EL}}
 
 ExpTime-vollständig
 

--- a/chapters/800_uebersicht.tex
+++ b/chapters/800_uebersicht.tex
@@ -48,7 +48,7 @@ Wir betrachten hier beispielhaft die Erweiterung von um konkrete Bereiche. Dazu 
 
 Jedes $\EL$-Konzept ist erfüllbar bzgl. jeder TBox.
 
-\subsection{Subsumtion in $\EL$ ohne TBox}
+\subsection{Subsumtion in \texorpdfstring{$\EL$}{EL} ohne TBox}
 
 Subsumtion in $\EL$ kann in polynomieller Zeit entschieden werden:
 

--- a/chapters/800_uebersicht.tex
+++ b/chapters/800_uebersicht.tex
@@ -6,7 +6,7 @@ Komplexität: ExpTime-vollständig
 
 \paragraph{Obere Schranken}
 
-Um zu zeigen, dass die Erfüllbarkeit von $\ALC$ bzgl. TBoxen in ExpTime liegt, haben wir den Algorithmus ``Typ-Elimination'' eingeführt.
+Um zu zeigen, dass die Erfüllbarkeit von $\ALC$ bzgl. TBoxen in ExpTime liegt, haben wir den Algorithmus \enquote{Typ-Elimination} eingeführt.
 
 Für diesen habe wir syntaktische Typen definiert und dann gezeigt, dass dieser in $2^\{|C_0|+|\MT|\}$ Schritten terminiert.
 
@@ -24,7 +24,7 @@ Komplexität: PSpace-vollständig
 
 \paragraph{Obere Schranken}
 
-Um zu zeigen, dass die Erfüllbarkeit von $\ALC$ ohne TBoxen in PSpace liegt, haben wir den Algorithmus ``$\ALC$-Worlds'' eingeführt.
+Um zu zeigen, dass die Erfüllbarkeit von $\ALC$ ohne TBoxen in PSpace liegt, haben wir den Algorithmus \enquote{$\ALC$-Worlds} eingeführt.
 
 Für diesen haben wir i-Typen definiert und dann gezeigt, dass der Algorithmus terminiert und in PSpace liegt. Dies liegt daran, dass der Algorithmus einen endlichen Baum bildet, und wir nur einen Pfad zur selben Zeit betrachten müssen, da wir per Tiefensuche prüfen.
 

--- a/main.tex
+++ b/main.tex
@@ -6,13 +6,6 @@
 
 	\settitlepage{} % number of report
 
-	\setpagestyle
-	\pagestyle{fancy}
-	\renewcommand{\headrulewidth}{0.1pt}
-	%\setlength{\headheight}{1cm}
-	\fancyhead[R]{ }
-	\fancyhead[L]{\leftmark}
-	\fancyfoot[C]{\thepage}
 	\settableofcontents
 
 	% \listoftodos[Todos]

--- a/settings/newcommands.tex
+++ b/settings/newcommands.tex
@@ -22,6 +22,7 @@
 \newcommand{\ALCI}{\mathcal{A}\mathcal{L}\mathcal{C}\mathcal{I}}
 \newcommand{\ALCQ}{\mathcal{A}\mathcal{L}\mathcal{C}\mathcal{Q}}
 \newcommand{\ALCQI}{\mathcal{A}\mathcal{L}\mathcal{Q}\mathcal{I}}
+\let\emptyset\varnothing
 
 % leftragged tablecontent with size
 \newcolumntype{E}[1]{>{\raggedright\arraybackslash}p{#1}}

--- a/settings/pagelayout.tex
+++ b/settings/pagelayout.tex
@@ -10,7 +10,7 @@
                 \LARGE \textbf{Beschreibungslogik} \\
 
                 \vspace{3cm}
-                \Large Mitschriften / "Lecture Notes"\\
+                \Large Mitschriften / \enquote{Lecture Notes}\\
         \end{center}
     \end{minipage}
     \vfill

--- a/settings/pagelayout.tex
+++ b/settings/pagelayout.tex
@@ -33,15 +33,6 @@
     \newpage
 }
 
-\newcommand{\setpagestyle} {
-    \pagestyle{fancy}
-    \renewcommand{\headrulewidth}{0.1pt}
-    %\setlength{\headheight}{1cm}
-    %\fancyhead[R]{Test}
-    \fancyhead[L]{\leftmark}
-    \fancyfoot[C]{\thepage}
-}
-
 \newcommand{\settableofcontents} {
     \setcounter{tocdepth}{4}
     \tableofcontents

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -24,9 +24,6 @@
 \usepackage{xcolor}
 \usepackage{csquotes} % for \enquote
 
-\usepackage{xparse,nameref} % for chapref
-\NewDocumentCommand{\chapref}{s m}{~\ref{#2}\IfBooleanF{#1}{ \nameref{#2}}.}
-
 \setlength\parindent{0pt}
 \let\emptyset\varnothing
 %%%%%%%%%%%%%%%%%%%

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -8,20 +8,15 @@
 % The usepackage's should be cleaned one day...
 
 \usepackage{graphicx} 	% show graphics
-\usepackage{listings} 	% show code listings
-\usepackage{tabularx} 	% different table-env
 \usepackage{hyperref} 	% use urls, link to sections, mail-addresses
-\usepackage{enumitem}   % for enumerate
 \usepackage{xargs}      % for more than one opt parameter in newcommands
-                        % coloured text etc.
+
 \usepackage{amssymb}
 \usepackage{amsthm}
 \usepackage{mathtools}
-\usepackage{wasysym}    % Box with checkmark
 \usepackage{stmaryrd} % for bigsqcap
 \usepackage{tabu} % for tables with defined width
 \usepackage[sort]{natbib} % For quotationn
-\usepackage{enumitem}% http://ctan.org/pkg/enumitem
 \usepackage{pgfplots}
 \pgfplotsset{compat=1.14}
 \usepackage{tabto}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -11,7 +11,6 @@
 \usepackage{listings} 	% show code listings
 \usepackage{tabularx} 	% different table-env
 \usepackage{hyperref} 	% use urls, link to sections, mail-addresses
-\usepackage{cite}		% for citation
 \usepackage{enumitem}   % for enumerate
 \usepackage{xargs}      % for more than one opt parameter in newcommands
                         % coloured text etc.
@@ -21,7 +20,7 @@
 \usepackage{wasysym}    % Box with checkmark
 \usepackage{stmaryrd} % for bigsqcap
 \usepackage{tabu} % for tables with defined width
-\usepackage{natbib} % For quotationn
+\usepackage[sort]{natbib} % For quotationn
 \usepackage{enumitem}% http://ctan.org/pkg/enumitem
 \usepackage{pgfplots}
 \usepackage{tabto}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{template}
+\ProvidesClass{settings/template}
 \LoadClass[12pt,a4paper,oneside]{scrartcl}
 
 \usepackage[utf8]{inputenc}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -24,8 +24,6 @@
 \usepackage{xcolor}
 \usepackage{csquotes} % for \enquote
 
-\setlength\parindent{0pt}
-\let\emptyset\varnothing
 %%%%%%%%%%%%%%%%%%%
 % Define Theorems %
 %%%%%%%%%%%%%%%%%%%
@@ -50,26 +48,13 @@
 %%%%%%%%%%%%%
 % page size %
 %%%%%%%%%%%%%
-%\usepackage{showframe}  % show layout
-%\setlength{\topmargin}{-1cm}
-%\setlength{\headheight}{15pt}
-%\setlength{\evensidemargin}{0cm}
-%\setlength{\oddsidemargin}{0cm}
-%\setlength{\textheight}{24cm}
-%\setlength{\textwidth}{15cm}
-%\setlength{\marginparwidth}{2.5cm}
-%\setlength{\parskip}{1ex}
-%\setlength{\parindent}{0ex}
-
 \usepackage[top=1in, bottom=1in, left=1in, right=1in]{geometry}
 
 %%%%%%%%%%%%%
 % paragraph %
 %%%%%%%%%%%%%
-%\usepackage{setspace}
-%\doublespacing
-%\setlength\parindent{0.5cm}
 \setlength{\parskip}{2mm}
+\setlength\parindent{0pt}
 
 % TIKZ %
 \usepackage{tikz}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -23,6 +23,7 @@
 \usepackage[sort]{natbib} % For quotationn
 \usepackage{enumitem}% http://ctan.org/pkg/enumitem
 \usepackage{pgfplots}
+\pgfplotsset{compat=1.14}
 \usepackage{tabto}
 \usepackage{todonotes}
 \usepackage{xcolor}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -27,6 +27,7 @@
 \usepackage{tabto}
 \usepackage{todonotes}
 \usepackage{xcolor}
+\usepackage{csquotes} % for \enquote
 
 \usepackage{xparse,nameref} % for chapref
 \NewDocumentCommand{\chapref}{s m}{~\ref{#2}\IfBooleanF{#1}{ \nameref{#2}}.}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -13,7 +13,6 @@
 \usepackage{hyperref} 	% use urls, link to sections, mail-addresses
 \usepackage{cite}		% for citation
 \usepackage{enumitem}   % for enumerate
-\usepackage{scrextend}  % for addmargin
 \usepackage{xargs}      % for more than one opt parameter in newcommands
                         % coloured text etc.
 \usepackage{amssymb}

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -47,7 +47,7 @@
 \usepackage[headsepline]{scrlayer-scrpage}
 \renewcommand\sectionmarkformat{\thesection\autodot\quad}
 %\setkomafont{pageheadfoot}{\footnotesize\scshape}
-\setheadsepline{.1pt}
+\KOMAoption{headsepline}{.1pt:}
 \automark{part}
 \automark*{section}
 \clearpairofpagestyles% entfernen der voreingestellten Inhalte

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -33,7 +33,6 @@
 \usepackage{xparse,nameref} % for chapref
 \NewDocumentCommand{\chapref}{s m}{~\ref{#2}\IfBooleanF{#1}{ \nameref{#2}}.}
 
-\usepackage{textgreek} % Use for example textepsilon
 \setlength\parindent{0pt}
 \let\emptyset\varnothing
 %%%%%%%%%%%%%%%%%%%

--- a/settings/template.cls
+++ b/settings/template.cls
@@ -7,7 +7,6 @@
 
 % The usepackage's should be cleaned one day...
 
-\usepackage{fancyhdr} 	% fancy header and footer
 \usepackage{graphicx} 	% show graphics
 \usepackage{listings} 	% show code listings
 \usepackage{tabularx} 	% different table-env
@@ -46,6 +45,15 @@
 \newtheorem{proposition}[definition]{Proposition}
 
 
+\usepackage[headsepline]{scrlayer-scrpage}
+\renewcommand\sectionmarkformat{\thesection\autodot\quad}
+%\setkomafont{pageheadfoot}{\footnotesize\scshape}
+\setheadsepline{.1pt}
+\automark{part}
+\automark*{section}
+\clearpairofpagestyles% entfernen der voreingestellten Inhalte
+\cfoot{\pagemark}
+\ihead{\rightbotmark}
 
 %%%%%%%%%%%%%
 % page size %


### PR DESCRIPTION
Hallo Sascha,

ich besuche dieses Semester BL und würde gerne, wenn ich Zeit finde, ein wenig an disem Skript arbeiten.

Folgende Änderungen sind in diesem PR:

* Nicht benötigte Pakete entfernt
* Warnungen behoben
* Quotationmarks in "deutsche" umgewandelt

Weiterhin würde ich gerne alle Links durch `\autoref` ersetzen, allerdigs arbeitet das nur durch einen Hack mit newtheorem zusammen, weswegen ich noch überlege wie man das am geschicktesten anstellen kann.
